### PR TITLE
Display public key in multiformat hash on profile page

### DIFF
--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -167,13 +167,19 @@ class Profile extends React.Component {
     );
   }
 
+  MultiformatDisplay(key) {
+    if(!key) { return; }
+
+    return `kupk${client.utils.AddressToHash(key, true)}`;
+  }
+
   PrivateAndPublicKeys(signer) {
     return (
       <span className="key-container">
         <IconButton icon={KeyIcon} label={`${this.state.showKey ? "Hide" : "Show"} Private and Public Keys`} onClick={() => this.setState({showKey: !this.state.showKey})}/>
         <span className={`private-public-keys ${this.state.showKey ? "visible" : ""}`}>
           <span className="key-info">{this.state.showKey ? `Private: ${signer.privateKey}` : "" }</span>
-          <span className="key-info">{ this.state.showKey ? `Public: ${signer.signingKey.keyPair.publicKey}` : "" }</span>
+          <span className="key-info">{ this.state.showKey ? `Public: ${this.MultiformatDisplay(signer.signingKey.keyPair.publicKey)}` : "" }</span>
         </span>
       </span>
     );


### PR DESCRIPTION
On the Profile page, display the user's public key in multiformat, beginning with kupk.