### PR TITLE
Remove word break from key info

### DIFF
--- a/src/static/stylesheets/profile.scss
+++ b/src/static/stylesheets/profile.scss
@@ -177,7 +177,7 @@
     .key-info {
       display: inline-flex;
       text-align: left;
-      word-break: break-all;
+      word-break: keep-all;
 
       &:first-child {
         margin-bottom: $elv-spacing-xs;

--- a/src/static/stylesheets/profile.scss
+++ b/src/static/stylesheets/profile.scss
@@ -176,6 +176,7 @@
 
     .key-info {
       display: inline-flex;
+      font-size: 10px;
       text-align: left;
       word-break: keep-all;
 


### PR DESCRIPTION
Currently, the public key wraps in the Profile view. Remove the word break for key-info.

