### PR TITLE
Initialize searchClient and use for clientMode=search

### DIFF
--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -270,7 +270,16 @@ class AppFrame extends React.Component {
         }
 
         const responder = (response) => this.Respond(response.requestId, source, response);
-        await this.props.rootStore.client.CallFromFrameMessage(event.data, responder);
+
+        if(
+          event.data.args &&
+          event.data.args.clientMode &&
+          event.data.args.clientMode === "search"
+        ) {
+          await this.props.rootStore.searchClient.CallFromFrameMessage(event.data, responder);
+        } else {
+          await this.props.rootStore.client.CallFromFrameMessage(event.data, responder);
+        }
     }
   }
 


### PR DESCRIPTION
Changes for using search URIs in the HttpClient.
- Listen for `clientMode=search` in `ApiRequestListener`. When that is provided, invoke `CallFromFrameMessage` on the searchClient instead of the client. Otherwise, default to the client.
- Initialize `searchClient` in the rootStore.