### PR TITLE
allow configuration of port number (and path) via environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "3.1.15",
   "scripts": {
     "bump-version": "npm --git-tag-version --no-commit-hooks version patch",
-    "serve": "webpack-dev-server --host 0.0.0.0 --hot --port 8082",
+    "serve": "webpack-dev-server --host 0.0.0.0 --hot",
     "build": "node ./node_modules/webpack-cli/bin/cli.js --mode=production --devtool false",
     "build-analyze": "ANALYZE_BUNDLE=true node ./node_modules/webpack-cli/bin/cli.js --mode=production --devtool false",
     "lint": "npm run fix-scss ; npm run lint-scss ; npm run fix-js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,15 +32,14 @@ module.exports = env => {
       clean: true,
       //filename: "main.js",
       filename: "[name].bundle.js",
-      //publicPath: process.env.ASSET_PATH,
-      publicPath: "/",
+      publicPath: process.env.ELV_CORE_JS_ASSET_PATH || "/",
       chunkFilename: "bundle.[id].[chunkhash].js"
     },
     devServer: {
       hot: true,
       historyApiFallback: true,
       allowedHosts: "all",
-      port: 8082,
+      port: process.env.ELV_CORE_JS_PORT || 8082,
       headers: {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Headers": "Content-Type, Accept",


### PR DESCRIPTION
super simple PR to make dev life a tiny bit easier

ELV_CORE_JS_PORT to set port number (default is still 8082) 

ELV_CORE_JS_ASSET_PATH to set asset path (default is still "/")

doing this to allow fewer "noise" diffs when having local deployments that may not be on the "standard" port number for various reasons